### PR TITLE
feat: Apply Gruvbox theme and update CLI tools

### DIFF
--- a/modules/common/alacritty.nix
+++ b/modules/common/alacritty.nix
@@ -62,82 +62,65 @@ in
         thickness = 0.2;
       };
       
-      # Catppuccin Mocha theme
+      # Gruvbox Dark theme
       colors = {
         primary = {
-          background = "#1e1e2e";
-          foreground = "#cdd6f4";
-          # dim_foreground = "#7f849c"; # Not a standard alacritty primary option
-          # bright_foreground = "#cdd6f4"; # Not a standard alacritty primary option
+          background = "0x1d2021";
+          foreground = "0xd4be98";
         };
         cursor = {
-          text = "#1e1e2e";
-          cursor = "#f5e0dc";
+          text = "0x1d2021";
+          cursor = "0xec5d2a";
         };
         vi_mode_cursor = {
-          text = "#1e1e2e";
-          cursor = "#b4befe";
+          text = "0x1d2021";
+          cursor = "0xec5d2a";
         };
         search = {
           matches = {
-            foreground = "#1e1e2e";
-            background = "#a6adc8";
+            foreground = "0x1d2021";
+            background = "0x7daea3"; # blue
           };
           focused_match = {
-            foreground = "#1e1e2e";
-            background = "#a6e3a1";
+            foreground = "0x1d2021";
+            background = "0xa9b665"; # green
           };
-        };
-        footer_bar = { # This might not be a standard Alacritty option, will check.
-                       # Update: Alacritty docs confirm 'footer_bar' is valid.
-          foreground = "#1e1e2e";
-          background = "#a6adc8";
         };
         hints = {
           start = {
-            foreground = "#1e1e2e";
-            background = "#f9e2af";
+            foreground = "0x1d2021";
+            background = "0xd8a657"; # yellow
           };
           end = {
-            foreground = "#1e1e2e";
-            background = "#a6adc8";
+            foreground = "0x1d2021";
+            background = "0x7daea3"; # blue
           };
         };
         selection = {
-          text = "#1e1e2e";
-          background = "#f5e0dc";
+          text = "0xd4be98";
+          background = "0x32302f";
         };
         normal = {
-          black = "#45475a";
-          red = "#f38ba8";
-          green = "#a6e3a1";
-          yellow = "#f9e2af";
-          blue = "#89b4fa";
-          magenta = "#f5c2e7";
-          cyan = "#94e2d5";
-          white = "#bac2de";
+          black = "0x32302f";
+          red = "0xea6962";
+          green = "0xa9b665";
+          yellow = "0xd8a657";
+          blue = "0x7daea3";
+          magenta = "0xd3869b";
+          cyan = "0x89b482";
+          white = "0xd4be98";
         };
         bright = {
-          black = "#585b70";
-          red = "#f38ba8";
-          green = "#a6e3a1";
-          yellow = "#f9e2af";
-          blue = "#89b4fa";
-          magenta = "#f5c2e7";
-          cyan = "#94e2d5";
-          white = "#a6adc8";
+          black = "0x32302f";
+          red = "0xea6962";
+          green = "0xa9b665";
+          yellow = "0xd8a657";
+          blue = "0x7daea3";
+          magenta = "0xd3869b";
+          cyan = "0x89b482";
+          white = "0xd4be98";
         };
-        # dim_foreground and bright_foreground from the TOML root are general palette colors.
-        # Alacritty also has top-level `dim` and `bright` sections for *all* dim/bright colors if needed,
-        # but Catppuccin provides them per color (normal.black, bright.black etc), which is standard.
-        # The specific `dim_foreground` from the TOML root was "#7f849c".
-        # If needed, one could set `colors.dim.foreground = "#7f849c";` but this is not standard.
-        # The TOML also had a root `bright_foreground = "#cdd6f4"`, which is the same as primary.foreground.
-
-        indexed_colors = [
-          { index = 16; color = "#fab387"; }
-          { index = 17; color = "#f5e0dc"; }
-        ];
+        # Gruvbox theme doesn't typically use indexed_colors
       };
       
       # Essential key bindings

--- a/modules/common/cli.nix
+++ b/modules/common/cli.nix
@@ -26,7 +26,7 @@
   programs.bat = {
     enable = true;
     config = {
-      theme = "Catppuccin-Mocha"; # Updated theme
+      theme = "gruvbox-dark"; # Updated theme
       italic-text = "always";
       style = "numbers,changes,header";
     };
@@ -56,7 +56,7 @@
     delta = {
       enable = true;
       options = {
-        syntax-theme = "Catppuccin-Mocha"; # Updated theme
+        syntax-theme = "gruvbox-dark"; # Updated theme
         side-by-side = true;
         line-numbers = true;
       };

--- a/modules/common/data/aliases.zsh
+++ b/modules/common/data/aliases.zsh
@@ -51,8 +51,8 @@ alias gcm='git commit -m'
 alias gcam='git commit -a -m'
 alias gcad='git commit -a --amend'
 alias gp='git push'
-alias gl='git log --graph --pretty=format:"%Cblue%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold cyan)<%an>%Creset"'
-alias gll='git log --graph --pretty=format:"%Cblue%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold cyan)<%an>%Creset" --all'
+alias gl='git log --graph --pretty=format:"%C(blue)%h%Creset -%C(yellow)%d%Creset %s %C(green)(%cr) %C(cyan)<%an>%Creset"'
+alias gll='git log --graph --pretty=format:"%C(blue)%h%Creset -%C(yellow)%d%Creset %s %C(green)(%cr) %C(cyan)<%an>%Creset" --all'
 
 # Compression
 compress() { tar -czf "${1%/}.tar.gz" "${1%/}"; }

--- a/modules/common/data/p10k.zsh
+++ b/modules/common/data/p10k.zsh
@@ -26,44 +26,44 @@
   typeset -g POWERLEVEL9K_PROMPT_ON_NEWLINE=true            # Prompt on new line
   typeset -g POWERLEVEL9K_PROMPT_ADD_NEWLINE=true           # Add newline before prompt
   typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_PREFIX=''  # No prefix for first line
-  typeset -g POWERLEVEL9K_MULTILINE_LAST_PROMPT_PREFIX='%F{230}╰──' # Cream prefix with icon
+  typeset -g POWERLEVEL9K_MULTILINE_LAST_PROMPT_PREFIX='%F{223}╰──' # Gruvbox Light Yellow prefix with icon
   typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_GAP_CHAR='─' # Horizontal line char
-  typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_GAP_FOREGROUND='29' # Dark green line
+  typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_GAP_FOREGROUND='106' # Gruvbox Green line
 
   # Arrows between segments
-  typeset -g POWERLEVEL9K_LEFT_SUBSEGMENT_SEPARATOR='%F{37}%f'  # Teal arrow
-  typeset -g POWERLEVEL9K_RIGHT_SUBSEGMENT_SEPARATOR='%F{30}%f' # Cyan arrow
+  typeset -g POWERLEVEL9K_LEFT_SUBSEGMENT_SEPARATOR='%F{72}%f'  # Gruvbox Cyan arrow
+  typeset -g POWERLEVEL9K_RIGHT_SUBSEGMENT_SEPARATOR='%F{108}%f' # Gruvbox Light Cyan arrow
   typeset -g POWERLEVEL9K_LEFT_SEGMENT_SEPARATOR=''              # No extra separator
   typeset -g POWERLEVEL9K_RIGHT_SEGMENT_SEPARATOR=''             # No extra separator
 
-  # Colors: white text/icons, teal/dark green/cyan accents
-  typeset -g POWERLEVEL9K_DIR_FOREGROUND='255'              # White text for directory
-  typeset -g POWERLEVEL9K_DIR_BACKGROUND='37'               # Brighter teal background
-  typeset -g POWERLEVEL9K_VCS_CLEAN_FOREGROUND='255'        # White text for clean VCS
-  typeset -g POWERLEVEL9K_VCS_CLEAN_BACKGROUND='29'         # Dark green background
-  typeset -g POWERLEVEL9K_VCS_MODIFIED_FOREGROUND='255'     # White text for modified VCS
-  typeset -g POWERLEVEL9K_VCS_MODIFIED_BACKGROUND='30'      # Cyan background
-  typeset -g POWERLEVEL9K_VCS_UNTRACKED_FOREGROUND='255'    # White text for untracked VCS
-  typeset -g POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND='37'     # Brighter teal background
-  typeset -g POWERLEVEL9K_STATUS_OK_FOREGROUND='255'        # White text for OK status
-  typeset -g POWERLEVEL9K_STATUS_OK_BACKGROUND='29'         # Dark green background
-  typeset -g POWERLEVEL9K_STATUS_ERROR_FOREGROUND='255'     # White text for error status
-  typeset -g POWERLEVEL9K_STATUS_ERROR_BACKGROUND='160'     # Dark red background
-  typeset -g POWERLEVEL9K_TIME_FOREGROUND='255'             # White text for time
-  typeset -g POWERLEVEL9K_TIME_BACKGROUND='30'              # Cyan background
+  # Colors: Gruvbox scheme
+  typeset -g POWERLEVEL9K_DIR_FOREGROUND='223'              # Gruvbox Light Yellow text for directory
+  typeset -g POWERLEVEL9K_DIR_BACKGROUND='66'               # Gruvbox Blue background
+  typeset -g POWERLEVEL9K_VCS_CLEAN_FOREGROUND='223'        # Gruvbox Light Yellow text for clean VCS
+  typeset -g POWERLEVEL9K_VCS_CLEAN_BACKGROUND='106'         # Gruvbox Green background
+  typeset -g POWERLEVEL9K_VCS_MODIFIED_FOREGROUND='223'     # Gruvbox Light Yellow text for modified VCS
+  typeset -g POWERLEVEL9K_VCS_MODIFIED_BACKGROUND='72'      # Gruvbox Cyan background
+  typeset -g POWERLEVEL9K_VCS_UNTRACKED_FOREGROUND='223'    # Gruvbox Light Yellow text for untracked VCS
+  typeset -g POWERLEVEL9K_VCS_UNTRACKED_BACKGROUND='66'     # Gruvbox Blue background
+  typeset -g POWERLEVEL9K_STATUS_OK_FOREGROUND='223'        # Gruvbox Light Yellow text for OK status
+  typeset -g POWERLEVEL9K_STATUS_OK_BACKGROUND='106'         # Gruvbox Green background
+  typeset -g POWERLEVEL9K_STATUS_ERROR_FOREGROUND='223'     # Gruvbox Light Yellow text for error status
+  typeset -g POWERLEVEL9K_STATUS_ERROR_BACKGROUND='124'     # Gruvbox Red background
+  typeset -g POWERLEVEL9K_TIME_FOREGROUND='223'             # Gruvbox Light Yellow text for time
+  typeset -g POWERLEVEL9K_TIME_BACKGROUND='72'              # Gruvbox Cyan background
 
   # Prompt symbol
-  typeset -g POWERLEVEL9K_PROMPT_CHAR_OK_VIINS_FOREGROUND='230'  # Cream for OK prompt
-  typeset -g POWERLEVEL9K_PROMPT_CHAR_OK_VIINS_BACKGROUND='29'   # Dark green background
-  typeset -g POWERLEVEL9K_PROMPT_CHAR_ERROR_VIINS_FOREGROUND='230' # Cream for error prompt
-  typeset -g POWERLEVEL9K_PROMPT_CHAR_ERROR_VIINS_BACKGROUND='160' # Dark red background
+  typeset -g POWERLEVEL9K_PROMPT_CHAR_OK_VIINS_FOREGROUND='223'  # Gruvbox Light Yellow for OK prompt
+  typeset -g POWERLEVEL9K_PROMPT_CHAR_OK_VIINS_BACKGROUND='106'   # Gruvbox Green background
+  typeset -g POWERLEVEL9K_PROMPT_CHAR_ERROR_VIINS_FOREGROUND='223' # Gruvbox Light Yellow for error prompt
+  typeset -g POWERLEVEL9K_PROMPT_CHAR_ERROR_VIINS_BACKGROUND='124' # Gruvbox Red background
   typeset -g POWERLEVEL9K_PROMPT_CHAR_CONTENT_EXPANSION='-'      # Unicode prompt symbol
 
   # Icon styling - Unicode icons
-  typeset -g POWERLEVEL9K_VCS_GIT_ICON='%F{230}⭠ '              # Cream Git icon
-  typeset -g POWERLEVEL9K_VCS_STAGED_ICON='%F{230}✚'            # Cream staged icon
-  typeset -g POWERLEVEL9K_VCS_UNSTAGED_ICON='%F{230}●'          # Cream unstaged icon
-  typeset -g POWERLEVEL9K_VCS_UNTRACKED_ICON='%F{230}…'         # Cream untracked icon
+  typeset -g POWERLEVEL9K_VCS_GIT_ICON='%F{223}⭠ '              # Gruvbox Light Yellow Git icon
+  typeset -g POWERLEVEL9K_VCS_STAGED_ICON='%F{223}✚'            # Gruvbox Light Yellow staged icon
+  typeset -g POWERLEVEL9K_VCS_UNSTAGED_ICON='%F{223}●'          # Gruvbox Light Yellow unstaged icon
+  typeset -g POWERLEVEL9K_VCS_UNTRACKED_ICON='%F{223}…'         # Gruvbox Light Yellow untracked icon
 
   # Truncation and other settings
   typeset -g POWERLEVEL9K_SHORTEN_DIR_LENGTH=2                  # Truncate directory to 2 segments

--- a/modules/common/zsh.nix
+++ b/modules/common/zsh.nix
@@ -108,14 +108,14 @@
         eval "$(atuin init zsh)"
       fi
 
-      # Environment variables with Catppuccin Mocha theme
-      export BAT_THEME="Catppuccin-Mocha"
+      # Environment variables with Gruvbox Dark theme
+      export BAT_THEME="gruvbox-dark"
       export BAT_STYLE="header,grid"  # Show file headers and borders
       export DELTA_FEATURES="+side-by-side" # Delta theme will be set in cli.nix
       export RIPGREP_CONFIG_PATH="$HOME/.ripgreprc"
       export LESS="-R" # Ensures `less` processes color codes correctly
-      # Catppuccin Mocha LS_COLORS from https://github.com/catppuccin/dircolors
-      export LS_COLORS="rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=00:tw=30;42:ow=34;40:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:"
+      # Gruvbox Dark LS_COLORS (adapted from Solarized dircolors by seebi)
+      export LS_COLORS="rs=0:di=01;38;5;66:ln=01;38;5;108:mh=00:pi=48;5;235;38;5;172;01:so=48;5;235;38;5;132;01:do=48;5;235;38;5;132;01:bd=48;5;235;38;5;223;01:cd=48;5;235;38;5;223;01:or=48;5;235;38;5;124;01:mi=00:su=38;5;229;48;5;124:sg=38;5;229;48;5;172:ca=00:tw=38;5;229;48;5;106:ow=38;5;66;48;5;235:st=38;5;229;48;5;72:ex=01;38;5;106:*.tar=01;38;5;124:*.tgz=01;38;5;124:*.arc=01;38;5;124:*.arj=01;38;5;124:*.taz=01;38;5;124:*.lha=01;38;5;124:*.lz4=01;38;5;124:*.lzh=01;38;5;124:*.lzma=01;38;5;124:*.tlz=01;38;5;124:*.txz=01;38;5;124:*.tzo=01;38;5;124:*.t7z=01;38;5;124:*.zip=01;38;5;124:*.z=01;38;5;124:*.dz=01;38;5;124:*.gz=01;38;5;124:*.lrz=01;38;5;124:*.lz=01;38;5;124:*.lzo=01;38;5;124:*.xz=01;38;5;124:*.zst=01;38;5;124:*.tzst=01;38;5;124:*.bz2=01;38;5;124:*.bz=01;38;5;124:*.tbz=01;38;5;124:*.tbz2=01;38;5;124:*.tz=01;38;5;124:*.deb=01;38;5;124:*.rpm=01;38;5;124:*.jar=01;38;5;124:*.war=01;38;5;124:*.ear=01;38;5;124:*.sar=01;38;5;124:*.rar=01;38;5;124:*.alz=01;38;5;124:*.ace=01;38;5;124:*.zoo=01;38;5;124:*.cpio=01;38;5;124:*.7z=01;38;5;124:*.rz=01;38;5;124:*.cab=01;38;5;124:*.jpg=01;38;5;132:*.jpeg=01;38;5;132:*.mjpg=01;38;5;132:*.mjpeg=01;38;5;132:*.gif=01;38;5;132:*.bmp=01;38;5;132:*.pbm=01;38;5;132:*.pgm=01;38;5;132:*.ppm=01;38;5;132:*.tga=01;38;5;132:*.xbm=01;38;5;132:*.xpm=01;38;5;132:*.tif=01;38;5;132:*.tiff=01;38;5;132:*.png=01;38;5;132:*.svg=01;38;5;132:*.svgz=01;38;5;132:*.mng=01;38;5;132:*.pcx=01;38;5;132:*.mov=01;38;5;132:*.mpg=01;38;5;132:*.mpeg=01;38;5;132:*.m2v=01;38;5;132:*.mkv=01;38;5;132:*.webm=01;38;5;132:*.ogm=01;38;5;132:*.mp4=01;38;5;132:*.m4v=01;38;5;132:*.mp4v=01;38;5;132:*.vob=01;38;5;132:*.qt=01;38;5;132:*.nuv=01;38;5;132:*.wmv=01;38;5;132:*.asf=01;38;5;132:*.rm=01;38;5;132:*.rmvb=01;38;5;132:*.flc=01;38;5;132:*.avi=01;38;5;132:*.fli=01;38;5;132:*.flv=01;38;5;132:*.gl=01;38;5;132:*.dl=01;38;5;132:*.xcf=01;38;5;132:*.xwd=01;38;5;132:*.yuv=01;38;5;132:*.cgm=01;38;5;132:*.emf=01;38;5;132:*.ogv=01;38;5;132:*.ogx=01;38;5;132:*.aac=00;38;5;72:*.au=00;38;5;72:*.flac=00;38;5;72:*.m4a=00;38;5;72:*.mid=00;38;5;72:*.midi=00;38;5;72:*.mka=00;38;5;72:*.mp3=00;38;5;72:*.mpc=00;38;5;72:*.ogg=00;38;5;72:*.ra=00;38;5;72:*.wav=00;38;5;72:*.oga=00;38;5;72:*.opus=00;38;5;72:*.spx=00;38;5;72:*.xspf=00;38;5;72:"
 
       # Zsh settings
       setopt AUTO_CD              # Change directory by typing directory name
@@ -205,6 +205,7 @@
 
   # Install packages
   home.packages = with pkgs; [
+    # Existing CLI tools
     eza # Modern ls replacement (fork of the now archived exa)
     bat
     fd
@@ -214,27 +215,42 @@
     bottom
     tealdeer
     gitui
-    uutils-coreutils
-    sd
-    choose
-    zoxide
-    starship
-    zsh-powerlevel10k
-    fzf
-    jq
-    yq
-    difftastic
-    delta
-    hyperfine
-    gawk
-    git
-    atuin
-    just
-    miniserve
-    ouch
-    xh
-    qsv
-    macchina
-    zellij
+    uutils-coreutils # Modern coreutils replacement
+    sd # Modern sed alternative
+    choose # Modern cut alternative
+    zoxide # Smarter cd command
+    starship # Cross-shell prompt (though p10k is used)
+    zsh-powerlevel10k # Powerlevel10k Zsh theme
+    fzf # Command-line fuzzy finder
+    jq # JSON processor
+    yq # YAML processor
+    difftastic # Diff tool that understands syntax
+    delta # Git diff viewer
+    hyperfine # Command-line benchmarking tool
+    gawk # GNU awk
+    git # Version control system
+    atuin # Shell history manager
+    just # Modern make alternative
+    miniserve # Simple HTTP server
+    ouch # Compression/decompression utility
+    xh # Modern curl alternative
+    qsv # CSV processing utility
+    macchina # System information tool
+    zellij # Terminal multiplexer
+
+    # Common development tools
+    (if pkgs.stdenv.isDarwin then clang else gcc) # C/C++ compiler
+    make # Build automation tool
+    python3 # Python 3 interpreter
+    nodejs_20 # Node.js (LTS version 20)
+    go # Go programming language
+    rustc # Rust compiler
+    cargo # Rust package manager
+    openjdk17 # OpenJDK 17 (LTS version)
+    cmake # Cross-platform build system generator
+    pkg-config # Helper tool for compiling applications and libraries
+    openssl # Cryptography toolkit
+    curl # Command-line tool for transferring data with URLs
+    wget # Command-line tool for downloading files
   ];
 }


### PR DESCRIPTION
This commit introduces the following changes:

1.  **Theme Update to Gruvbox Dark:**
    *   Replaced the Catppuccin Mocha theme with Gruvbox Dark across various components:
        *   Alacritty terminal emulator.
        *   Zsh directory listing colors.
        *   `bat` pager theme (both environment variable and Nix config).
        *   `git delta` theme for diffs.
    *   Adjusted the Powerlevel10k Zsh prompt theme in `p10k.zsh` to align with the Gruvbox color palette.
    *   Updated color codes in `git log` aliases (`gl`, `gll`) to match Gruvbox.

2.  **CLI Tool Configuration Enhancements:**
    *   Added a selection of common development packages to `home.packages` in `modules/common/zsh.nix` to ensure their availability. This includes tools like `gcc`/`clang`, `make`, `python3`, `nodejs`, `go`, `rust`, `java`, `cmake`, etc.
    *   The existing `PATH` configuration in `zsh.nix` was reviewed and deemed suitable.

These changes address your request to change the color scheme to a nature-inspired one (Gruvbox) and to review/fix issues with CLI tools by ensuring common ones are installed.